### PR TITLE
fix: delete unused props from firebase config

### DIFF
--- a/services/firebase/firebase.ts
+++ b/services/firebase/firebase.ts
@@ -3,12 +3,10 @@ const env = import.meta.env;
 const firebaseConfig = {
   apiKey: env.PUBLIC_API_KEY,
   authDomain: env.PUBLIC_AUTH_DOMAIN,
-  databaseURL: env.PUBLIC_DATABASE_URL,
   projectId: env.PUBLIC_PROJECT_ID,
   storageBucket: env.PUBLIC_STORAGE_BUCKET,
   messagingSenderId: env.PUBLIC_MESSAGING_SENDER_ID,
   appId: env.PUBLIC_APP_ID,
-  measurementId: env.PUBLIC_MEASUREMENT_ID
 };
 
 const app = initializeApp(firebaseConfig);

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -12,8 +12,6 @@ interface ImportMetaEnv {
     readonly PUBLIC_STORAGE_BUCKET:string;
     readonly PUBLIC_MESSAGING_SENDER_ID:string;
     readonly PUBLIC_APP_ID:string;
-    readonly PUBLIC_MEASUREMENTID:string;
-    readonly PUBLIC_MEASUREMENT_ID:string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Deleted unused props from firebase config objects because there is no env equivilent.